### PR TITLE
Fix potree page to use CDN build

### DIFF
--- a/models/potini.html
+++ b/models/potini.html
@@ -7,7 +7,8 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
 	<title>Potini Tia</title>
 
-	<link rel="stylesheet" type="text/css" href="../build/potree/potree.css">
+       <!-- Use CDN build of Potree so we don't rely on a local build directory -->
+       <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/potree/potree@1.8/build/potree/potree.css">
 	<link rel="stylesheet" type="text/css" href="../libs/jquery-ui/jquery-ui.min.css">
 	<link rel="stylesheet" type="text/css" href="../libs/openlayers3/ol.css">
 	<link rel="stylesheet" type="text/css" href="../libs/spectrum/spectrum.css">
@@ -26,11 +27,12 @@
 	<script src="../libs/i18next/i18next.js"></script>
 	<script src="../libs/jstree/jstree.js"></script>
 	<script src="../libs/copc/index.js"></script>
-	<script src="../build/potree/potree.js"></script>
+       <!-- CDN script for Potree viewer -->
+       <script src="https://cdn.jsdelivr.net/gh/potree/potree@1.8/build/potree/potree.js"></script>
 	<script src="../libs/plasio/js/laslaz.js"></script>
 
 	<div class="potree_container" style="position: absolute; width: 100%; height: 100%; left: 0px; top: 0px; ">
-		<div id="potree_render_area" style="background-image: url('../build/potree/resources/images/background.jpg');"></div>
+               <div id="potree_render_area" style="background-image: url('../resources/images/background.jpg');"></div>
 		<div id="potree_sidebar_container"> </div>
 	</div>
 


### PR DESCRIPTION
## Summary
- use Potree assets from jsDelivr CDN
- load background image from local resources

## Testing
- `npm run` (fails: no tests defined)