### PR TITLE
Fix potree viewer path and clarify deployment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,14 @@ jobs:
       # ────── get code ──────
       - uses: actions/checkout@v4
 
+      # ────── build Potree ──────
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - run: |
+          npm ci
+          npm run build
+
       # ────── AWS creds ──────
       - uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
 # 3d-models
-Examples of 3D models created from photogrammetry techniques
+Examples of 3D models created from photogrammetry techniques.
+
+## Deployment
+
+The repository is designed to be hosted on S3 behind CloudFront.
+The GitHub Actions workflow builds the Potree viewer and uploads the
+site automatically.
+
+1. Install dependencies and build:
+
+   ```bash
+   npm ci
+   npm run build        # optional when using the CDN build
+   ```
+
+2. Sync the contents of this repository to your S3 bucket.
+   The `main.yml` workflow performs these steps and purges CloudFront
+   after each push to `main`.
+
+### CORS configuration
+
+Point cloud data lives in a separate public bucket. Ensure that bucket
+allows cross‑origin requests so the viewer can fetch `ept.json` and
+tiles from the browser.

--- a/models/potini.html
+++ b/models/potini.html
@@ -7,7 +7,8 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
 	<title>Potini Tia</title>
 
-	<link rel="stylesheet" type="text/css" href="../build/potree/potree.css">
+       <!-- Use CDN build of Potree so we don't rely on a local build directory -->
+       <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/potree@1.8.0/build/potree/potree.css">
 	<link rel="stylesheet" type="text/css" href="../libs/jquery-ui/jquery-ui.min.css">
 	<link rel="stylesheet" type="text/css" href="../libs/openlayers3/ol.css">
 	<link rel="stylesheet" type="text/css" href="../libs/spectrum/spectrum.css">
@@ -26,11 +27,12 @@
 	<script src="../libs/i18next/i18next.js"></script>
 	<script src="../libs/jstree/jstree.js"></script>
 	<script src="../libs/copc/index.js"></script>
-	<script src="../build/potree/potree.js"></script>
+       <!-- CDN script for Potree viewer -->
+       <script src="https://cdn.jsdelivr.net/npm/potree@1.8.0/build/potree/potree.js"></script>
 	<script src="../libs/plasio/js/laslaz.js"></script>
 
 	<div class="potree_container" style="position: absolute; width: 100%; height: 100%; left: 0px; top: 0px; ">
-		<div id="potree_render_area" style="background-image: url('../build/potree/resources/images/background.jpg');"></div>
+               <div id="potree_render_area" style="background-image: url('../resources/images/background.jpg');"></div>
 		<div id="potree_sidebar_container"> </div>
 	</div>
 


### PR DESCRIPTION
## Summary
- use npm CDN path for Potree assets in potini.html
- document how to deploy to S3 and why CORS is needed
- build Potree before upload in GitHub Actions workflow

## Testing
- `npm ci` *(fails: EHOSTUNREACH)*
- `npm run build` *(fails: gulp not found)*